### PR TITLE
Fix z-index for UYES button and draw pile

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -1,5 +1,5 @@
 #around-UYES{
-    z-index: -1;
+    z-index: 1;
     height: 100%;
     width: 100%;
     grid-row: 3;
@@ -110,7 +110,7 @@
 
 #piles {
 
-    z-index: -1;
+    z-index: 1;
     grid-row: 2;
     grid-column: 1/-1;
     display: flex;


### PR DESCRIPTION
## Summary
- keep the UYES button and draw pile clickable by raising their container z-index

## Testing
- `npm run lint` *(fails: no-unused-vars)*

------
https://chatgpt.com/codex/tasks/task_e_688d1abac5788332a08cb42a17a984f0