### PR TITLE
Enable UYES button during player's turn

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -331,7 +331,8 @@ body#gameplay {
 }
 
 .my-turn #UYES {
-    pointer-events: initial;
+    pointer-events: auto;
+    z-index: 10;
     background-color: var(--primary-yellow);
     border: solid 0.5cqh white;
 }


### PR DESCRIPTION
## Summary
- Allow UYES button to be clicked on the player's turn by enabling pointer events and raising its z-index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars and related errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e2bdf8eec8332b2ae35573bb2c2b1