### PR TITLE
fix: adjust pile layering and turn interaction

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -107,8 +107,8 @@
 }
 
 #piles {
-
-    z-index: 0;
+    position: relative;
+    z-index: 10;
     grid-row: 2;
     grid-column: 1/-1;
     display: flex;
@@ -118,7 +118,8 @@
     gap:25%;
 
     .pile {
-        z-index: 5;
+        position: relative;
+        z-index: 10;
         h2 {
             text-align: center;
             font-size: 2cqw;
@@ -336,6 +337,10 @@ body#gameplay {
     border: solid 0.5cqh white;
 }
 
+body.my-turn {
+    pointer-events: auto;
+}
+
 body#gameplay {
 
     #winner {
@@ -434,6 +439,8 @@ body#gameplay {
 }
 
 #draw-pile {
+    position: relative;
+    z-index: 10;
     pointer-events: none;
     cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- Ensure piles and draw pile appear above other elements by setting `position: relative` and `z-index: 10`
- Enable interaction when it's your turn with `body.my-turn { pointer-events: auto; }`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unused vars in unrelated files)*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688e2be778d08332bb0cefc646bc0029