### PR TITLE
fix: restrict player hand container hitbox

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -27,6 +27,7 @@
 }
 
 #player-hand-container {
+    position: relative;
     z-index: 5;
     grid-row: 3;
     grid-column: 2;
@@ -40,7 +41,17 @@
     overflow-x: auto;
     overflow-y: clip;
     gap: 0;
+    height: fit-content;
+    pointer-events: none;
 
+}
+
+#player-hand-container > span.card {
+    pointer-events: auto;
+}
+
+#player-hand-container > span.card.unplayable {
+    pointer-events: none;
 }
 
 /* prevent left overflow of the first card in hand */


### PR DESCRIPTION
## Summary
- position player hand container relative with z-index to scope overlay
- limit hitbox to card area using height fit-content and pointer-events
- restore pointer events for playable cards while keeping unplayable cards inert

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e2be5c9a08332a7873f8e3848d4a4