### PR TITLE
Allow pointer events on player hand container

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -42,7 +42,7 @@
     overflow-y: clip;
     gap: 0;
     height: fit-content;
-    pointer-events: none;
+    pointer-events: auto;
 
 }
 


### PR DESCRIPTION
## Summary
- enable pointer events on `#player-hand-container` for user interaction
- retain pointer events on card spans to preserve drag and click behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars in unrelated files)*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688e2fe4f9488332a942f449c69f3d6b