### PR TITLE
Enable UYES button interaction regardless of turn

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -18,7 +18,6 @@
 
     aspect-ratio: 2.5/1;
     width: 10%;
-    pointer-events: none;
     background-color: dimgrey;
     border: solid 0.5cqh darkgrey; /* ❗️cqh = container-height unit – bitte check Kompatibilität */
     border-radius: 15%;
@@ -343,7 +342,6 @@ body#gameplay {
 }
 
 .my-turn #UYES {
-    pointer-events: auto;
     z-index: 10;
     background-color: var(--primary-yellow);
     border: solid 0.5cqh white;


### PR DESCRIPTION
## Summary
- Make UYES button interactive by default and keep turn-based styling hook.
- Confirm turn updates toggle `my-turn` class on `<body>` for styling.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: '_id' is assigned a value but never used, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_688e2fe389488332967930ae53886158