### PR TITLE
Fix UYES button layering

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -2,19 +2,22 @@
     height: 100%;
     width: 100%;
     grid-row: 3;
-    grid-column: 1/-1;
+    grid-column: 2;
     position: relative;
+    z-index: 4;
+    pointer-events: none;
 }
 
 #UYES {
-    z-index: 5;
+    z-index: 10;
 
     position: absolute;
 
     left: 50%;
-    bottom:105%;
+    bottom:110%;
 
     transform: translateX(-50%);
+    pointer-events: auto;
 
     aspect-ratio: 2.5/1;
     width: 10%;


### PR DESCRIPTION
## Summary
- prevent UYES wrapper from intercepting clicks by lowering its z-index and disabling pointer events
- lift UYES button above the player hand and ensure it remains clickable

## Testing
- `npm run lint` *(fails: '_id' is assigned a value but never used', and other unused variable errors)*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688e327bc52483328c4b74e85ff8f1d4