### PR TITLE
Center UYES button under turn counter

### DIFF
--- a/public/html/gameplay.html
+++ b/public/html/gameplay.html
@@ -12,7 +12,6 @@
     <script src="/scripts/index.js" type="module" defer></script>
 </head>
 <body id="gameplay">
-<button id="UYES">UYES</button>
 <div id="milchglas2" class="hidden"></div>
 <div id="winner" class="hidden"><div class="player-name"></div></div>
 <div id="ending-buttons" class="hidden" style="display:none;">
@@ -87,6 +86,7 @@
 <div id="yourTurn">
     Your turn in:
     <div id="roundCountTurn">0</div>
+    <button id="UYES">UYES</button>
 </div>
 <div id="color-overlay" class="hidden">
     <div id="color-options">

--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -1,8 +1,8 @@
 #UYES {
     position: absolute;
     left: 50%;
-    top: 75%;
     transform: translateX(-50%);
+    top: calc(100% + 1cqw);
     z-index: 5;
     pointer-events: auto;
     aspect-ratio: 2.5/1;


### PR DESCRIPTION
## Summary
- Place UYES button within the turn indicator below the round counter
- Adjust UYES button CSS to center it relative to the turn container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: unused variable errors in existing files)*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688e384491488332a125c520111b07e1