### PR TITLE
style: elevate top back button

### DIFF
--- a/public/styles/generalStyles.css
+++ b/public/styles/generalStyles.css
@@ -57,6 +57,7 @@ button:active, .button:active {
 .backButtonTop{
     position: absolute;
     width: 10%;
+    z-index: 5;
 }
 
 div#header {


### PR DESCRIPTION
## Summary
- ensure top-level back buttons appear above other UI elements by assigning a z-index

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688e39045d0083329e7d56db2205bc54