### PR TITLE
style: adjust UYES button and center lobby names

### DIFF
--- a/public/styles/gameplay.css
+++ b/public/styles/gameplay.css
@@ -2,11 +2,11 @@
     position: absolute;
     left: 50%;
     transform: translateX(-50%);
-    top: calc(100% + 1cqw);
+    bottom: 20%;
     z-index: 5;
     pointer-events: auto;
     aspect-ratio: 2.5/1;
-    width: 10%;
+    width: 15%;
     background-color: dimgrey;
     border: solid 0.5cqh darkgrey; /* ❗️cqh = container-height unit – bitte check Kompatibilität */
     border-radius: 15%;

--- a/public/styles/lobby.css
+++ b/public/styles/lobby.css
@@ -119,6 +119,8 @@
     p{
 
         margin: 0;
+        width: 100%;
+        text-align: center;
         &.openSlot{
             color: dimgrey;
             +.removePlayerButton{


### PR DESCRIPTION
## Summary
- Raise and widen the UYES button for better visibility
- Center player names in lobby slots for host view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars)*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_688e39f4f14c8332b06645bf97a462d1