### PR TITLE
Fix kick button alignment in lobby

### DIFF
--- a/public/styles/lobby.css
+++ b/public/styles/lobby.css
@@ -107,7 +107,7 @@
 }
 
 .player-lobby-fields{
-    /*position: relative;*/
+    position: relative;
     width: 100%;
     /*height: 10%;*/
     flex-grow: 1;
@@ -139,16 +139,15 @@
                 justify-self: flex-end;
                 text-overflow: ellipsis;
 
-                transform: translateX(600%);
-
-                z-index: 5;
+                position: absolute;
+                right: 1cqw;
                 top: 0.1cqw;
                 font-size: 1cqw;
+                z-index: 5;
 
                 &:active{
-                    transform: translateX(600%) scale(1.2);
+                    transform: scale(1.2);
                     /*transform: initial;*/
-
                 }
 
 


### PR DESCRIPTION
## Summary
- Ensure `.player-lobby-fields` establishes positioning context
- Absolutely position lobby kick button instead of using translate transform

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 17 errors, no-unused-vars)*
- `npm run build:css`
- `curl -I http://localhost:5000/html/lobby.html`


------
https://chatgpt.com/codex/tasks/task_e_688e41cc6a588332b1b2dfccadd5e792