### PR TITLE
Limit player name length

### DIFF
--- a/public/html/createGame.html
+++ b/public/html/createGame.html
@@ -203,7 +203,7 @@
 <div id="menu-createGame">
     <form method="post" >
         <label for="NameInput"></label>
-        <input id="NameInput" type="text" placeholder="Enter your name here..." name="playerName" required>
+        <input id="NameInput" type="text" placeholder="Enter your name here..." name="playerName" required maxlength="17">
     </form>
     <button id="continue-createGame">CONTINUE</button>
 

--- a/public/html/joinLobby.html
+++ b/public/html/joinLobby.html
@@ -24,7 +24,7 @@
 <main class="joinLobby">
     <form method="POST" action="/api/joinGame">
         <label for="NameInput"></label>
-        <input id="NameInput" class="Join" type="text" placeholder="Enter your name here..." name="playerName">
+        <input id="NameInput" class="Join" type="text" placeholder="Enter your name here..." name="playerName" maxlength="17">
 
         <label for="gameCodeInput"></label>
         <input id="gameCodeInput" type="text" placeholder="Enter game-code here..." name="code" required>

--- a/public/scripts/createGame.js
+++ b/public/scripts/createGame.js
@@ -2,6 +2,8 @@
 import { handleIntro } from './utils/intros.js';
 import { setupAmountControls, setupSelectAllCheckbox } from './utils/uiHelpers.js';
 
+const MAX_NAME_LENGTH = 17;
+
 /** Initialise form controls for the create game page. */
 export function initCreateGame() {
 
@@ -24,8 +26,15 @@ export function initCreateGame() {
     document.getElementById("continue-createGame")?.addEventListener("click", async (e) => {
         e.preventDefault();
 
+        const name = document.getElementById("NameInput").value.trim() || "";
+
+        if (name.length > MAX_NAME_LENGTH) {
+            alert("❌ Name too long");
+            return;
+        }
+
         const data = {
-            name: document.getElementById("NameInput").value || "",
+            name,
             settings: {
                 players: document.getElementById("playerSlider").value,
                 cards: document.getElementById("cardSlider").value,
@@ -39,7 +48,6 @@ export function initCreateGame() {
         };
 
         sessionStorage.setItem("gameData", JSON.stringify(data));
-
 
         const response = await fetch("/api/createGame", {
             method: "POST",

--- a/public/scripts/joinLobby.js
+++ b/public/scripts/joinLobby.js
@@ -1,4 +1,6 @@
 // Join lobby form functionality
+const MAX_NAME_LENGTH = 17;
+
 export function initJoinLobby() {
 
     document.getElementById("joinBackBtn")?.addEventListener("click", () => {
@@ -17,6 +19,11 @@ export function initJoinLobby() {
 
         if (!/^\d{9}$/.test(code)) {
             alert("❌ Please enter a valid 9-digit game code");
+            return;
+        }
+
+        if (name.length > MAX_NAME_LENGTH) {
+            alert("❌ Name too long");
             return;
         }
 


### PR DESCRIPTION
## Summary
- restrict name input fields to 17 characters on join and create pages
- add client-side validation to reject names longer than 17 characters before contacting the server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-unused-vars in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688e41d284ac8332bc9b654ad79411dd