### PR TITLE
fix: remove duplicate MAX_NAME_LENGTH constant

### DIFF
--- a/backend/logic/lobbyHandling.js
+++ b/backend/logic/lobbyHandling.js
@@ -3,7 +3,7 @@
  * player joins without specifying one. Lobbies are identified by a
  * nine digit game code.
  */
-const MAX_NAME_LENGTH = "Draw Master Flash".length;
+export const MAX_NAME_LENGTH = 20;
 const funnyNames = [
     "U-Norris", "Taylor Swift", "UNO DiCaprio", "Cardi Bitch",
     "Elon Shuffle", "Snoop Draw Two", "Oprah Skipfrey", "Keanu Draw-Reeves",
@@ -25,7 +25,6 @@ function getRandomName() {
     return funnyNames[Math.floor(Math.random() * funnyNames.length)];
 }
 
-export const MAX_NAME_LENGTH = 20;
 
 /**
  * Generate a random nine digit lobby code.


### PR DESCRIPTION
## Summary
- export a single `MAX_NAME_LENGTH` constant in `lobbyHandling.js` to avoid duplicate declarations

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: multiple no-unused-vars errors in unrelated files)
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_688e46826fdc8332b4cfd2f322d5a659